### PR TITLE
Fix friend ID generation to ensure numeric IDs

### DIFF
--- a/src/services/friendsApi.ts
+++ b/src/services/friendsApi.ts
@@ -18,7 +18,18 @@ export const friendsApi = {
 
   // Add a new friend
   addFriend: async (friendData: FriendFormData): Promise<Friend> => {
-    const response = await axios.post(`${API_BASE_URL}/friends`, friendData);
+    // Get all friends first to determine the next ID
+    const allFriends = await friendsApi.getAllFriends();
+    const maxId = Math.max(...allFriends.map(friend => Number(friend.id)), 0);
+    const nextId = maxId + 1;
+    
+    // Create friend object with numeric ID
+    const friendWithId = {
+      ...friendData,
+      id: nextId
+    };
+    
+    const response = await axios.post(`${API_BASE_URL}/friends`, friendWithId);
     return response.data;
   },
 


### PR DESCRIPTION
- Update addFriend API to generate proper numeric IDs
- Get current max ID from existing friends and increment by 1
- Prevents json-server from auto-generating string IDs
- Ensures consistent numeric ID sequence (1, 2, 3, 4, 5, 6...)
- Fixes potential issues with friend detail page routing